### PR TITLE
Replace docker trust view by docker trust inspect

### DIFF
--- a/registry_trusted_content.md
+++ b/registry_trusted_content.md
@@ -159,7 +159,7 @@ You can review signed versions of an image repository or tag, including informat
     (Optional) Specify the tag, _&lt;tag&gt;_, to see information for that version of the image.
 
     ```
-    docker trust view <image>:<tag>
+    docker trust inspect <image>:<tag>
     ```
     {: pre}
 


### PR DESCRIPTION
The command view does not exist in `docker trust view `. So replace view by inspect.